### PR TITLE
Fixed crash caused by cleanupAccessoriesIds becoming unset

### DIFF
--- a/platform/index.js
+++ b/platform/index.js
@@ -265,7 +265,7 @@ class Platform {
       this.accessories.delete(id);
     });
 
-    delete this.cleanupAccessoriesIds;
+    this.cleanupAccessoriesIds.clear();
 
     if (!accessories.length) {
       return


### PR DESCRIPTION
Every time I add a new accessory the platform was crashing:

```
[12/28/2019, 4:15:26 PM] TypeError: Cannot read property 'delete' of undefined
    at Platform.onNodeAdded (/app/plugins/node_modules/homebridge-platform-zwave/platform/index.js:70:32)
    at Object.onNodeAdded (/app/plugins/node_modules/homebridge-platform-zwave/platform/index.js:33:35)
    at Controller.onNodeAdded (/app/plugins/node_modules/homebridge-platform-zwave/zwave/controller.js:304:48)
    at OZW.<anonymous> (/app/plugins/node_modules/homebridge-platform-zwave/zwave/controller.js:65:61)
    at OZW.emit (events.js:210:5)
```

I traced it to `Platform.cleanupAccessories` unsetting the `cleanupAccessoriesIds` set rather than clearing it out.