### PR TITLE
Update switchMultiLevel to Better Support Dimmers

### DIFF
--- a/platform/bridge.js
+++ b/platform/bridge.js
@@ -16,6 +16,10 @@ module.exports = class Bridge extends EventEmitter {
     );
   }
 
+  refreshValue(valueId, cb) {
+    this.platform.refreshNodeValue(valueId, cb);
+  }
+
   onValueChanged(valueId, cb) {
     this.on(`value.${valueId}.changed`, cb);
   }

--- a/platform/index.js
+++ b/platform/index.js
@@ -157,6 +157,11 @@ class Platform {
     }
   }
 
+  refreshNodeValue(valueId, cb) {
+    this.log.debug('refresh node value', valueId);
+    this.controller.refreshNodeValue(valueId, cb);
+  }
+
   setNodeParameters(node, parameters) {
     if (!parameters) {
       return

--- a/zwave/classes/switchMultiLevel.js
+++ b/zwave/classes/switchMultiLevel.js
@@ -36,21 +36,10 @@ function bind({ Service, Characteristic, bridge, accessory, node, values }) {
   } else {
     // in case device doesn't have the switch binary class
     on
-      .on('set', (value, cb) => bridge.getValue(valueId, (err, level) => {
-        if (err) {
-          return cb(err);
-        }
-
-        if (value && level === 0) {
-          return bridge.setValue(valueId, 100, cb);
-        }
-
-        if (!value && level !== 0) {
-          return bridge.setValue(valueId, 0, cb);
-        }
-
-        cb();
-      }))
+      .on('set', (value, cb) => {
+        bridge.setValue(valueId, value ? 0xFF : 0x00, cb);
+        setTimeout(bridge.refreshValue.bind(bridge, valueId, null), 5000);
+      })
       .on('get', cb => bridge.getValue(valueId, (err, value) =>
         cb(err, value >= 1)
       ));

--- a/zwave/controller.js
+++ b/zwave/controller.js
@@ -130,6 +130,26 @@ class Controller {
     }
   }
 
+  refreshNodeValue(valueId, cb) {
+    try {
+      const args = valueId.split('-').map(Number);
+      const node = this.nodes.get(args[0]);
+      this.driver.refreshValue.apply(this.driver, args);
+
+      if (cb) {
+        cb(null);
+      }
+    } catch (e) {
+      console.log('refresh node value error', e);
+      if (cb) {
+        cb(e);
+        return;
+      }
+
+      throw e;
+    }
+  }
+
   addNode(isSecure, cbs = {}) {
     this.beginControllerCommand('addNode', [ isSecure ], cbs);
   }


### PR DESCRIPTION
My dimmer switches (GE 12724) weren’t quite working right.  Turning off worked, but turning on didn’t — unless I explicitly set the brightness level.

Since I’m migrating from SmartThings, I dug into how they did it, and [found this](https://docs.smartthings.com/en/latest/device-type-developers-guide/building-z-wave-device-handlers.html#sending-commands):

>Many Z-Wave commands use 8-bit integers to represent device state. Generally 0 means “off” or “inactive”, 1-99 are used as percentage values for a variable level attribute, and 0xFF or 255 (the highest value) means “on” or “detected”.

I tried it, and sure enough, 0xFF works as a special “on” signal to the dimmer where it turns back on the prior level.

Since SmartThings makes device handlers public, I also took a look at how exactly they’re turning dimmers on and off in their generic dimmer device handler: https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy#L206-L211

I wasn’t able to leverage `getNodeValue` because it reads from cache, so I added `refreshNodeValue` throughout and I have it firing 5s after an on/off even like SmartThings does.