### PR TITLE
Added support for Fans via new hints config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If you want to customize exposed accessories, add `accessories` to your config. 
 - values – map of `valueId: value` to set the initial value.
 - parameters – map of `parameterId: value` to set the initial value.
 - valuesMaps – map of `valueId: valueMaps` to map a value from Z-Wave to HomeKit.
+- hints – set of strings to help better understand the device.
 
 You can also set the node config to `false` to ignore the node (device) entirely.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ If you want to customize exposed accessories, add `accessories` to your config. 
       "ignoreClasses": [ 38 ],
       "values": {
         "112-1-35": 37
-      }
+      },
+      "hints": [ "fan" ]
     }
   }
 }
@@ -70,7 +71,7 @@ If you want to customize exposed accessories, add `accessories` to your config. 
 - values – map of `valueId: value` to set the initial value.
 - parameters – map of `parameterId: value` to set the initial value.
 - valuesMaps – map of `valueId: valueMaps` to map a value from Z-Wave to HomeKit.
-- hints – set of strings to help better understand the device.
+- hints – set of strings to help better understand the device.  Currently only `fan` is supported.
 
 You can also set the node config to `false` to ignore the node (device) entirely.
 

--- a/platform/accessory.js
+++ b/platform/accessory.js
@@ -4,7 +4,8 @@ const zWaveClasses = require('../zwave');
 function configureAccessory({ Service, Characteristic, accessory, bridge, node, config = {} }) {
   const {
     classes: deviceClasses = {},
-    ignoreClasses = []
+    ignoreClasses = [],
+    hints = []
   } = config;
   const nodeValues = node.values;
 
@@ -27,7 +28,8 @@ function configureAccessory({ Service, Characteristic, accessory, bridge, node, 
       bridge,
       accessory,
       node,
-      values: [ ...values ].map(id => nodeValues.get(id))
+      values: [ ...values ].map(id => nodeValues.get(id)),
+      hints: new Set(hints || [])
     });
   });
 

--- a/zwave/classes/switchMultiLevel.js
+++ b/zwave/classes/switchMultiLevel.js
@@ -16,24 +16,25 @@ const index = {
   targetValue: 9
 }
 
-function bind({ Service, Characteristic, bridge, accessory, node, values }) {
+function bind({ Service, Characteristic, bridge, accessory, node, values, hints }) {
   const switchBinaryValues = getClassValues(node, switchBinaryClassId);
   const switchBinaryValue = getValueByIndex(switchBinaryValues, switchBinaryIndex.level);
   const switchBinaryValueId = switchBinaryValue ? switchBinaryValue.value_id : null;
 
   const { value_id: valueId } = getValueByIndex(values, index.level);
 
-  const serviceLightbulb = getOrAddService(accessory, Service.Lightbulb);
-  const on = serviceLightbulb.getCharacteristic(Characteristic.On);
-  const brightness = serviceLightbulb.getCharacteristic(Characteristic.Brightness);
+  const isFan = hints.has('fan');
+  const serviceLightbulb = getOrAddService(accessory, isFan ? Service.Fanv2 : Service.Lightbulb);
+  const on = isFan ? null : serviceLightbulb.getCharacteristic(Characteristic.On);
+  const brightness = serviceLightbulb.getCharacteristic(isFan ? Characteristic.RotationSpeed : Characteristic.Brightness);
 
-  if (switchBinaryValueId) {
+  if (on && switchBinaryValueId) {
     on
       .on('set', (value, cb) => bridge.setValue(switchBinaryValueId, value, cb))
       .on('get', cb => bridge.getValue(switchBinaryValueId, cb));
 
     bridge.onValueChanged(switchBinaryValueId, value => on.updateValue(value));
-  } else {
+  } else if(on) {
     // in case device doesn't have the switch binary class
     on
       .on('set', (value, cb) => bridge.getValue(valueId, (err, level) => {
@@ -61,13 +62,13 @@ function bind({ Service, Characteristic, bridge, accessory, node, values }) {
     .on('get', cb => bridge.getValue(valueId, cb));
 
   // if device has switchBinary class as well sync it too
-  const serviceSwitch = accessory.getService(Service.Switch);
+  const serviceSwitch = on && accessory.getService(Service.Switch);
   const switchOn = serviceSwitch && serviceSwitch.getCharacteristic(Characteristic.On);
 
   bridge.onValueChanged(valueId, value => {
     const onState = value >= 1;
     brightness.updateValue(value);
-    on.updateValue(onState);
+    on && on.updateValue(onState);
     switchOn && switchOn.updateValue(onState);
   });
 }


### PR DESCRIPTION
As far as I can tell, there’s no official fan support in Z-Wave.  There’s no command classes listed here: http://wiki.micasaverde.com/index.php/ZWave_Command_Classes

The fan control I have (GE 12730) is treated exactly the same as a regular dimmer in the OZW DB: https://github.com/OpenZWave/open-zwave/blob/master/config/manufacturer_specific.xml#L764-L768

I opted to add a generic `hints` param to accessory config so `switchMultiLevel` can adjust it’s behavior.